### PR TITLE
[WIP] add options to filter tracks longer than 15min

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -8,6 +8,9 @@
     }
   },
   "version": "2.3",
+  "permissions": [
+    "storage"
+  ],
   "host_permissions": [
     "*://*.soundcloud.com/*"
   ],
@@ -18,5 +21,8 @@
       "run_at": "document_start",
       "world": "MAIN"
     }
-  ]
+  ],
+  "options_ui": {
+    "page": "options.html"
+  }
 }

--- a/options.css
+++ b/options.css
@@ -1,0 +1,6 @@
+.row {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    margin: 16px 0 16px 0;
+}

--- a/options.html
+++ b/options.html
@@ -1,0 +1,26 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="utf-8">
+    <link href="options.css" rel="stylesheet">
+  </head>
+  <body>
+    <form name="optionsForm">
+
+	  <div class="row">
+        <label>Track duration filter</label>
+        <div>
+          <label>
+            <input type="radio" name="maxTrackDurationMs" value="0">
+            <span>Allow any track duration</span>
+          </label>
+          <label>
+            <input type="radio" name="maxTrackDurationMs" value="900000">
+            <span>Block tracks longer than 15min</span>
+          </label>
+        </div>
+      </div>
+    </form>
+    <script src="options.js"></script>
+  </body>
+</html>

--- a/options.js
+++ b/options.js
@@ -1,0 +1,25 @@
+"use strict";
+
+async function init() {
+    let options = await chrome.storage.sync.get("repostBlocker");
+
+    let maxTrackDurationMs = options["maxTrackDurationMs"];
+    document.optionsForm.maxTrackDurationMs.value = maxTrackDurationMs ?? 0;
+
+    for (let radio of document.optionsForm.maxTrackDurationMs) {
+        radio.addEventListener("change", async (e) => {
+			let currentOptions = await chrome.storage.sync.get("repostBlocker");
+			currentOptions["maxTrackDurationMs"] = e.target.value;
+            console.log('maxTrackDurationMs: ' + maxTrackDurationMs);
+			await chrome.storage.sync.set(currentOptions, function() {
+			  console.log('Settings saved' + currentOptions);
+			});
+        });
+    }
+}
+
+if (document.readyState === "loading") {
+    document.addEventListener("DOMContentLoaded", init);
+} else {
+    init();
+}


### PR DESCRIPTION
Hey,
I can see that you wanted to keep the extension simple, but maybe this change is still "simple enough".
I often only want actual tracks and no dj sets in my feed and with this you can block any track longer than 15min.

The options page I just copied from your other sc2mp3 project so it should be a similiar coding style.
Anyway I hope that you could help me:
The saving of the option via chrome.storage does not work somehow(as I mentioned I just copied it from your other project).
Already tried a few differnet options but couldnt get it to work.

I would appreciate a lot if you could give me a hint what I missing, even if you would not consoder this change for your extension.